### PR TITLE
multivariate -> multivariable (closes #58)

### DIFF
--- a/slides/u1_d02-data-and-viz/u1_d02-data-and-viz.Rmd
+++ b/slides/u1_d02-data-and-viz/u1_d02-data-and-viz.Rmd
@@ -415,7 +415,7 @@ class: center, middle
 
 * Univariate data analysis - distribution of single variable
 * Bivariate data analysis - relationship between two variables
-* Multivariate data analysis - relationship between many variables at once, usually focusing on the relationship between two while conditioning for others
+* Multivariable data analysis - relationship between many variables at once, usually focusing on the relationship between two while conditioning for others
 
 ---
 


### PR DESCRIPTION
Right now I have just updated the .Rmd file to read "multivariable" instead of "multivariate" (based on [these definitions](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3518362/)). I have left "univariate" and "bivariate" since I know those are commonly used and I don't think there is a paper on the conventions here, but pedagogically it seems a bit mis-matched so I'd be happy to change to something else. My understanding broadly is:

- variate refers to the # of dependent variables
- variable refers to the # of independent variables

(i.e. multiVARIABLE = a model with one outcome, many predictors, as is referenced on this slide, multiVARIATE = a model with many outcomes, any # of predictors)

with this convention, what is currently being referred to a "bivariate" I would call "univariable" and I don't really have a stat term for what is currently referred to as "univariate". I got some input on this on [twitter](https://twitter.com/LucyStats/status/1095324236800016385) a few months ago, but again no consensus.

