### PR TITLE
GitHub action to check rmd renders for PRs to course materials

### DIFF
--- a/.github/workflows/check-render-rmd.yaml
+++ b/.github/workflows/check-render-rmd.yaml
@@ -1,0 +1,38 @@
+on:
+  pull_request:
+    branches: master
+    paths: 
+    - 'course-materials/**'
+
+name: Check course materials render
+
+jobs:
+  render:
+    name: Check course materials render
+    runs-on: macOS-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+    
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 2 # This is important to set for `git diff-tree` to work below
+    
+      - uses: r-lib/actions/setup-r@v1
+    
+      - uses: r-lib/actions/setup-pandoc@v1
+    
+      - name: Install packages
+        run: |
+         #install.packages(c("rmarkdown", "tidyverse", "renv", "remotes"))
+         install.packages(c("rmarkdown", "remotes"))
+         remotes::install_github(c("rundel/checklist", "rstudio-education/dsbox", "hadley/emo"))
+        shell: Rscript {0}
+    
+      - name: Check R Markdown files render
+        run: |
+          changed_files = system("git diff-tree --no-commit-id --name-only -r HEAD", intern = TRUE, wait = TRUE)
+          changed_rmd_files = changed_files[grepl("course-materials/.*\\.[Rr]md", changed_files)]
+          print(changed_rmd_files) # for debugging
+          lapply(changed_rmd_files, checklist::check_rmd_renders, install_missing = TRUE)
+        shell: Rscript {0}


### PR DESCRIPTION
First crack at check rmd renders for PRs to course materials is here.

Currently, it's not working properly because `git diff-tree --no-commit-id --name-only -r HEAD` doesn't yield the expected result when running the action. This is evidenced by `print(changed_rmd_files)` yielding `character(0)` when, in reality, an Rmd file was changed in the PR.

@jimhester suggested this is likely because the pull request is likely checked out as a single commit without history.

Need to still find an alternative to `git diff-tree --no-commit-id --name-only -r HEAD` that works in this context.

Closes #103.

