### PR TITLE
fixed html widget issue

### DIFF
--- a/course-materials/slides/u2-d10-data-types/u2-d10-data-types.Rmd
+++ b/course-materials/slides/u2-d10-data-types/u2-d10-data-types.Rmd
@@ -86,6 +86,7 @@ glimpse(cat_lovers)
 
 .small[
 ```{r echo=FALSE}
+options(htmltools.preserve.raw = FALSE)
 cat_lovers %>%
   datatable()
 ```

--- a/course-materials/slides/u2-d11-text-analysis/u2-d11-text-analysis.Rmd
+++ b/course-materials/slides/u2-d11-text-analysis/u2-d11-text-analysis.Rmd
@@ -296,6 +296,7 @@ sheeran <- artist_albums %>%
 
 .small[
 ```{r echo=FALSE}
+options(htmltools.preserve.raw = FALSE)
 sheeran %>%
   distinct(album, track_title) %>%
   datatable(options = list(dom = "p"))

--- a/course-materials/slides/u2-d19-top-250-imdb/u2-d19-top-250-imdb.Rmd
+++ b/course-materials/slides/u2-d19-top-250-imdb/u2-d19-top-250-imdb.Rmd
@@ -428,6 +428,7 @@ imdb_top_250
 ---
 
 ```{r echo=FALSE}
+options(htmltools.preserve.raw = FALSE)
 imdb_top_250 %>% datatable(options(list(dom = "p", pageLength = 8)), height = 400)
 ```
 


### PR DESCRIPTION
The html widgets are no longer rendering in the .html files (e.g., https://rstudio-education.github.io/datascience-box/course-materials/slides/u2-d10-data-types/u2-d10-data-types.html#8) due to a recent update to RMarkdown (https://stackoverflow.com/questions/65766516/xaringan-presentation-not-displaying-html-widgets-even-when-knitting-provided-t) . Adding options(htmltools.preserve.raw = FALSE) fixes the issues. I think this could also be fixed by adding options(htmltools.preserve.raw = FALSE) once to setup.Rmd but I did not know if that would change behavior elsewhere unexpectedly (tested these 3 .html and everything seemed back to normal.    

Thank you for all the awesome material!  