### PR TITLE
lab 10, lab 11: update stale identifiers

### DIFF
--- a/course-materials/lab-instructions/lab-10/lab-10-slr-course-evals.Rmd
+++ b/course-materials/lab-instructions/lab-10/lab-10-slr-course-evals.Rmd
@@ -57,10 +57,10 @@ library(openintro)
 
 ## Data
 
-The data can be found in the **dsbox** package, and it's called `evals`.
+The data can be found in the **openintro** package, and it's called `evals`.
 Since the dataset is distributed with the package, we don't need to load it separately; it becomes available to us when we load the package.
 You can find out more about the dataset by inspecting its documentation, which you can access by running `?evals` in the Console or using the Help menu in RStudio to search for `evals`.
-You can also find this information [here](https://rstudio-education.github.io/dsbox/reference/evals.html).
+You can also find this information [here](https://www.openintro.org/data/index.php?data=evals).
 
 # Exercises
 
@@ -79,7 +79,7 @@ You can also find this information [here](https://rstudio-education.github.io/ds
 **Hint:** See the help page for the function at http://ggplot2.tidyverse.org/reference/index.html.
 ```
 
-3.  Recreate the scatterplot from Exercise 3, but this time use\
+3.  Recreate the scatterplot from Exercise 2, but this time use\
     `geom_jitter()`? What does "jitter" mean? What was misleading about the initial scatterplot?
 
 🧶 ✅ ⬆️ *If you haven't done so recently, knit, commit, and push your changes to GitHub with an appropriate commit message. Make sure to commit and push all changed files so that your Git pane is cleared up afterwards.*
@@ -94,7 +94,7 @@ Linear model is in the form $\hat{y} = b_0 + b_1 x$.
     Fit a linear model called `score_bty_fit` to predict average professor evaluation `score` by average beauty rating (`bty_avg`).
     Based on the regression output, write the linear model.
 
-5.  Recreate the scatterplot from Exercise 3, and add the regression line to this plot in orange colour, with shading for the uncertainty of the line turned off.
+5.  Recreate the scatterplot from Exercise 2, and add the regression line to this plot in orange colour, with shading for the uncertainty of the line turned off.
 
 6.  Interpret the slope of the linear model in context of the data.
 
@@ -119,7 +119,7 @@ Linear model is in the form $\hat{y} = b_0 + b_1 x$.
 12. Create a new variable called `rank_relevel` where `"tenure track"` is the baseline level.
 
 13. Fit a new linear model called `score_bty_rank_relevel` to predict average professor evaluation `score` based on `rank_relevel` of the professor.
-    This is the new (releveled) variable you created in Exercise 13.
+    This is the new (releveled) variable you created in Exercise 12.
     Based on the regression output, write the linear model and interpret the slopes and intercept in context of the data.
     Also determine and interpret the $R^2$ of the model.
 

--- a/course-materials/lab-instructions/lab-10/lab-10-slr-course-evals.html
+++ b/course-materials/lab-instructions/lab-10/lab-10-slr-course-evals.html
@@ -33,6 +33,7 @@
 pre > code.sourceCode { white-space: pre; position: relative; }
 pre > code.sourceCode > span { display: inline-block; line-height: 1.25; }
 pre > code.sourceCode > span:empty { height: 1.2em; }
+.sourceCode { overflow: visible; }
 code.sourceCode > span { color: inherit; text-decoration: inherit; }
 div.sourceCode { margin: 1em 0; }
 pre.sourceCode { margin: 0; }
@@ -163,7 +164,7 @@ code span.wa { color: #60a0b0; font-weight: bold; font-style: italic; } /* Warni
 </div>
 <div id="data" class="section level2">
 <h2>Data</h2>
-<p>The data can be found in the <strong>dsbox</strong> package, and it’s called <code>evals</code>. Since the dataset is distributed with the package, we don’t need to load it separately; it becomes available to us when we load the package. You can find out more about the dataset by inspecting its documentation, which you can access by running <code>?evals</code> in the Console or using the Help menu in RStudio to search for <code>evals</code>. You can also find this information <a href="https://rstudio-education.github.io/dsbox/reference/evals.html">here</a>.</p>
+<p>The data can be found in the <strong>openintro</strong> package, and it’s called <code>evals</code>. Since the dataset is distributed with the package, we don’t need to load it separately; it becomes available to us when we load the package. You can find out more about the dataset by inspecting its documentation, which you can access by running <code>?evals</code> in the Console or using the Help menu in RStudio to search for <code>evals</code>. You can also find this information <a href="https://www.openintro.org/data/index.php?data=evals">here</a>.</p>
 </div>
 </div>
 <div id="exercises" class="section level1">
@@ -176,7 +177,7 @@ code span.wa { color: #60a0b0; font-weight: bold; font-style: italic; } /* Warni
 </ol>
 <p><label for="tufte-mn-1" class="margin-toggle">⊕</label><input type="checkbox" id="tufte-mn-1" class="margin-toggle"><span class="marginnote"><span style="display: block;"><strong>Hint:</strong> See the help page for the function at <a href="http://ggplot2.tidyverse.org/reference/index.html" class="uri">http://ggplot2.tidyverse.org/reference/index.html</a>.</span></span></p>
 <ol start="3" style="list-style-type: decimal">
-<li>Recreate the scatterplot from Exercise 3, but this time use<br />
+<li>Recreate the scatterplot from Exercise 2, but this time use<br />
 <code>geom_jitter()</code>? What does “jitter” mean? What was misleading about the initial scatterplot?</li>
 </ol>
 <p>🧶 ✅ ⬆️ <em>If you haven’t done so recently, knit, commit, and push your changes to GitHub with an appropriate commit message. Make sure to commit and push all changed files so that your Git pane is cleared up afterwards.</em></p>
@@ -186,7 +187,7 @@ code span.wa { color: #60a0b0; font-weight: bold; font-style: italic; } /* Warni
 <p><label for="tufte-mn-2" class="margin-toggle">⊕</label><input type="checkbox" id="tufte-mn-2" class="margin-toggle"><span class="marginnote"><span style="display: block;">Linear model is in the form <span class="math inline"><span class="math inline">\(\hat{y} = b_0 + b_1 x\)</span></span>.</span></span></p>
 <ol start="4" style="list-style-type: decimal">
 <li><p>Let’s see if the apparent trend in the plot is something more than natural variation. Fit a linear model called <code>score_bty_fit</code> to predict average professor evaluation <code>score</code> by average beauty rating (<code>bty_avg</code>). Based on the regression output, write the linear model.</p></li>
-<li><p>Recreate the scatterplot from Exercise 3, and add the regression line to this plot in orange colour, with shading for the uncertainty of the line turned off.</p></li>
+<li><p>Recreate the scatterplot from Exercise 2, and add the regression line to this plot in orange colour, with shading for the uncertainty of the line turned off.</p></li>
 <li><p>Interpret the slope of the linear model in context of the data.</p></li>
 <li><p>Interpret the intercept of the linear model in context of the data. Comment on whether or not the intercept makes sense in this context.</p></li>
 <li><p>Determine the <span class="math inline">\(R^2\)</span> of the model and interpret it in context of the data.</p></li>
@@ -200,7 +201,7 @@ code span.wa { color: #60a0b0; font-weight: bold; font-style: italic; } /* Warni
 <li><p>What is the equation of the line corresponding to male professors? What is it for female professors?</p></li>
 <li><p>Fit a new linear model called <code>score_bty_rank</code> to predict average professor evaluation <code>score</code> based on <code>rank</code> of the professor. Based on the regression output, write the linear model and interpret the slopes and intercept in context of the data.</p></li>
 <li><p>Create a new variable called <code>rank_relevel</code> where <code>&quot;tenure track&quot;</code> is the baseline level.</p></li>
-<li><p>Fit a new linear model called <code>score_bty_rank_relevel</code> to predict average professor evaluation <code>score</code> based on <code>rank_relevel</code> of the professor. This is the new (releveled) variable you created in Exercise 13. Based on the regression output, write the linear model and interpret the slopes and intercept in context of the data. Also determine and interpret the <span class="math inline">\(R^2\)</span> of the model.</p></li>
+<li><p>Fit a new linear model called <code>score_bty_rank_relevel</code> to predict average professor evaluation <code>score</code> based on <code>rank_relevel</code> of the professor. This is the new (releveled) variable you created in Exercise 12. Based on the regression output, write the linear model and interpret the slopes and intercept in context of the data. Also determine and interpret the <span class="math inline">\(R^2\)</span> of the model.</p></li>
 <li><p>Create another new variable called <code>tenure_eligible</code> that labels <code>&quot;teaching&quot;</code> faculty as <code>&quot;no&quot;</code> and labels <code>&quot;tenure track&quot;</code> and <code>&quot;tenured&quot;</code> faculty as <code>&quot;yes&quot;</code>.</p></li>
 <li><p>Fit a new linear model called <code>score_bty_tenure_eligible</code> to predict average professor evaluation <code>score</code> based on <code>tenure_eligible</code>ness of the professor. This is the new (regrouped) variable you created in the previous exercise. Based on the regression output, write the linear model and interpret the slopes and intercept in context of the data. Also determine and interpret the <span class="math inline">\(R^2\)</span> of the model.</p></li>
 </ol>

--- a/course-materials/lab-instructions/lab-11/lab-11-mlr-course-evals.Rmd
+++ b/course-materials/lab-instructions/lab-11/lab-11-mlr-course-evals.Rmd
@@ -52,10 +52,10 @@ library(openintro)
 
 ## Data
 
-The data can be found in the **dsbox** package, and it's called `evals`.
+The data can be found in the **openintro** package, and it's called `evals`.
 Since the dataset is distributed with the package, we don't need to load it separately; it becomes available to us when we load the package.
 You can find out more about the dataset by inspecting its documentation, which you can access by running `?evals` in the Console or using the Help menu in RStudio to search for `evals`.
-You can also find this information [here](https://rstudio-education.github.io/dsbox/reference/evals.html).
+You can also find this information [here](https://www.openintro.org/data/index.php?data=evals).
 
 # Exercises
 

--- a/course-materials/lab-instructions/lab-11/lab-11-mlr-course-evals.html
+++ b/course-materials/lab-instructions/lab-11/lab-11-mlr-course-evals.html
@@ -33,6 +33,7 @@
 pre > code.sourceCode { white-space: pre; position: relative; }
 pre > code.sourceCode > span { display: inline-block; line-height: 1.25; }
 pre > code.sourceCode > span:empty { height: 1.2em; }
+.sourceCode { overflow: visible; }
 code.sourceCode > span { color: inherit; text-decoration: inherit; }
 div.sourceCode { margin: 1em 0; }
 pre.sourceCode { margin: 0; }
@@ -138,6 +139,14 @@ code span.wa { color: #60a0b0; font-weight: bold; font-style: italic; } /* Warni
 
 <p>In this lab we revisit the professor evaluations data we modelled in the previous lab. In the last lab we modelled evaluation scores using a single predictor at a time. This time we will use multiple predictors to model evaluation scores.</p>
 <p>For context, review the previous lab’s introduction before continuing on to the exercises.</p>
+<div id="learning-goals" class="section level1">
+<h1>Learning goals</h1>
+<ul>
+<li>Fitting a linear regression with multiple predictors</li>
+<li>Interpreting regression output in context of the data</li>
+<li>Comparing models</li>
+</ul>
+</div>
 <div id="getting-started" class="section level1">
 <h1>Getting started</h1>
 <p>Go to the course GitHub organization and locate your homework repo, clone it in RStudio and open the R Markdown document. Knit the document to make sure it compiles without errors.</p>
@@ -154,7 +163,7 @@ code span.wa { color: #60a0b0; font-weight: bold; font-style: italic; } /* Warni
 </div>
 <div id="data" class="section level2">
 <h2>Data</h2>
-<p>The data can be found in the <strong>dsbox</strong> package, and it’s called <code>evals</code>. Since the dataset is distributed with the package, we don’t need to load it separately; it becomes available to us when we load the package. You can find out more about the dataset by inspecting its documentation, which you can access by running <code>?evals</code> in the Console or using the Help menu in RStudio to search for <code>evals</code>. You can also find this information <a href="https://rstudio-education.github.io/dsbox/reference/evals.html">here</a>.</p>
+<p>The data can be found in the <strong>openintro</strong> package, and it’s called <code>evals</code>. Since the dataset is distributed with the package, we don’t need to load it separately; it becomes available to us when we load the package. You can find out more about the dataset by inspecting its documentation, which you can access by running <code>?evals</code> in the Console or using the Help menu in RStudio to search for <code>evals</code>. You can also find this information <a href="https://www.openintro.org/data/index.php?data=evals">here</a>.</p>
 </div>
 </div>
 <div id="exercises" class="section level1">


### PR DESCRIPTION
Refactor labs that use `openintro`'s `evals` dataset to point to the right package name and codebook link. Also update stale exercise numbers in lab 10.