### PR TITLE
Fix mismatched lecture video link

### DIFF
--- a/02-ethics.Rmd
+++ b/02-ethics.Rmd
@@ -65,7 +65,7 @@ Course lectures are supplemented with "guest lectures" from domain experts.
 :::
 
 ::: {.video}
-[Video](https://youtu.be/c4fvdoNbcSw)
+[Video](https://youtu.be/E2eD72pwtps)
 :::
 :::
 


### PR DESCRIPTION
Algorithmic bias video link used to point to data privacy video, this patch fixes the link